### PR TITLE
Fix docs navigation by allowing inline scripts in CSP

### DIFF
--- a/internal/middleware/security.go
+++ b/internal/middleware/security.go
@@ -22,14 +22,15 @@ func SecurityHeaders(next http.Handler) http.Handler {
 
 		// Content Security Policy
 		// - default-src 'self': Only allow resources from same origin
-		// - script-src 'self': Only allow scripts from same origin
+		// - script-src 'self' 'unsafe-inline': Allow scripts from same origin + inline
+		//   (VitePress docs use inline scripts for dark mode/platform detection)
 		// - style-src 'self' 'unsafe-inline': Allow inline styles for UI frameworks
 		// - img-src 'self' data: https:: Allow images from self, data URIs, and HTTPS sources
 		// - connect-src 'self' ws: wss:: Allow API calls and WebSocket connections
 		// - frame-ancestors 'none': Prevent framing (redundant with X-Frame-Options but more modern)
 		w.Header().Set("Content-Security-Policy",
 			"default-src 'self'; "+
-				"script-src 'self'; "+
+				"script-src 'self' 'unsafe-inline'; "+
 				"style-src 'self' 'unsafe-inline'; "+
 				"img-src 'self' data: https:; "+
 				"connect-src 'self' ws: wss:; "+

--- a/internal/middleware/security_test.go
+++ b/internal/middleware/security_test.go
@@ -57,7 +57,7 @@ func TestSecurityHeaders(t *testing.T) {
 
 	cspDirectives := []string{
 		"default-src 'self'",
-		"script-src 'self'",
+		"script-src 'self' 'unsafe-inline'",
 		"frame-ancestors 'none'",
 	}
 


### PR DESCRIPTION
## Summary

- Add `'unsafe-inline'` to `script-src` in the Content-Security-Policy header
- VitePress docs use inline `<script>` tags for dark mode detection and platform checks
- The strict `script-src 'self'` policy blocked these, preventing the client-side router from initializing and breaking all page navigation

## Test plan

- [x] Security middleware unit tests pass
- [ ] Deploy and verify docs navigation works at `/docs/` (click Guide, Admin, Developer links)

🤖 Generated with [Claude Code](https://claude.com/claude-code)