### PR TITLE
Replace cluttered header with command palette and avatar dropdown

### DIFF
--- a/web/e2e/admin.spec.ts
+++ b/web/e2e/admin.spec.ts
@@ -3,16 +3,21 @@ import { test, expect } from '@playwright/test';
 test.describe('Admin Panel', () => {
   test.beforeEach(async ({ page }) => {
     await page.goto('/');
-    await expect(page.getByPlaceholder('Search applications...')).toBeVisible();
+    await expect(page.getByLabel('Manage sessions')).toBeVisible();
   });
 
+  const openAdminPanel = async (page: import('@playwright/test').Page) => {
+    await page.getByLabel('User menu').click();
+    await page.getByRole('button', { name: 'Admin Panel' }).click();
+  };
+
   test('opens admin panel', async ({ page }) => {
-    await page.getByRole('button', { name: /Admin settings/i }).click();
+    await openAdminPanel(page);
     await expect(page.getByRole('heading', { name: 'Admin Settings' })).toBeVisible();
   });
 
   test('shows all five tabs', async ({ page }) => {
-    await page.getByRole('button', { name: /Admin settings/i }).click();
+    await openAdminPanel(page);
     await expect(page.getByRole('heading', { name: 'Admin Settings' })).toBeVisible();
 
     for (const tab of ['Settings', 'Users', 'Apps', 'Templates', 'Sessions']) {
@@ -21,7 +26,7 @@ test.describe('Admin Panel', () => {
   });
 
   test('switches between tabs', async ({ page }) => {
-    await page.getByRole('button', { name: /Admin settings/i }).click();
+    await openAdminPanel(page);
     await expect(page.getByRole('heading', { name: 'Admin Settings' })).toBeVisible();
 
     // Click Users tab
@@ -45,7 +50,7 @@ test.describe('Admin Panel', () => {
     // Auto-accept confirmation dialogs for delete operations
     page.on('dialog', (dialog) => dialog.accept());
 
-    await page.getByRole('button', { name: /Admin settings/i }).click();
+    await openAdminPanel(page);
     await page.getByRole('button', { name: 'Users', exact: true }).click();
 
     // Open create user form
@@ -75,7 +80,7 @@ test.describe('Admin Panel', () => {
     // Auto-accept confirmation dialogs for delete operations
     page.on('dialog', (dialog) => dialog.accept());
 
-    await page.getByRole('button', { name: /Admin settings/i }).click();
+    await openAdminPanel(page);
     await page.getByRole('button', { name: 'Apps', exact: true }).click();
 
     // Open create app form
@@ -105,7 +110,7 @@ test.describe('Admin Panel', () => {
   });
 
   test('closes admin panel', async ({ page }) => {
-    await page.getByRole('button', { name: /Admin settings/i }).click();
+    await openAdminPanel(page);
     await expect(page.getByRole('heading', { name: 'Admin Settings' })).toBeVisible();
 
     // Close via the X button (first SVG close button in the panel)

--- a/web/e2e/auth.setup.ts
+++ b/web/e2e/auth.setup.ts
@@ -11,7 +11,7 @@ setup('authenticate as admin', async ({ page }) => {
   await page.getByRole('button', { name: 'Sign In' }).click();
 
   // Wait for dashboard to load
-  await expect(page.getByPlaceholder('Search applications...')).toBeVisible();
+  await expect(page.getByLabel('Manage sessions')).toBeVisible();
 
   // Save signed-in state
   await page.context().storageState({ path: ADMIN_FILE });

--- a/web/e2e/auth.spec.ts
+++ b/web/e2e/auth.spec.ts
@@ -17,9 +17,10 @@ test.describe('Authentication', () => {
     await page.getByRole('button', { name: 'Sign In' }).click();
 
     // Should reach the dashboard
-    await expect(page.getByPlaceholder('Search applications...')).toBeVisible();
-    // Admin should see admin button
-    await expect(page.getByRole('button', { name: /Admin settings/i })).toBeVisible();
+    await expect(page.getByLabel('Manage sessions')).toBeVisible();
+    // Admin should see admin items in user menu
+    await page.getByLabel('User menu').click();
+    await expect(page.getByRole('button', { name: 'Admin Panel' })).toBeVisible();
   });
 
   test('shows error for invalid credentials', async ({ page }) => {
@@ -53,10 +54,11 @@ test.describe('Authentication', () => {
     await page.getByLabel('Username').fill('admin');
     await page.getByLabel('Password').fill('admin123');
     await page.getByRole('button', { name: 'Sign In' }).click();
-    await expect(page.getByPlaceholder('Search applications...')).toBeVisible();
+    await expect(page.getByLabel('Manage sessions')).toBeVisible();
 
-    // Log out
-    await page.getByRole('button', { name: /Sign out/i }).click();
+    // Log out via user menu
+    await page.getByLabel('User menu').click();
+    await page.getByRole('button', { name: /Sign Out/i }).click();
 
     // Should be back at login
     await expect(page.getByText('Sign in to access your applications')).toBeVisible();
@@ -90,6 +92,6 @@ test.describe('Authentication', () => {
     await page.getByRole('button', { name: 'Create Account' }).click();
 
     // Should be auto-logged in to dashboard
-    await expect(page.getByPlaceholder('Search applications...')).toBeVisible();
+    await expect(page.getByLabel('Manage sessions')).toBeVisible();
   });
 });

--- a/web/e2e/dark-mode.spec.ts
+++ b/web/e2e/dark-mode.spec.ts
@@ -3,18 +3,19 @@ import { test, expect } from '@playwright/test';
 test.describe('Dark Mode', () => {
   test('toggles dark mode on and off', async ({ page }) => {
     await page.goto('/');
-    await expect(page.getByPlaceholder('Search applications...')).toBeVisible();
+    await expect(page.getByLabel('Manage sessions')).toBeVisible();
 
-    // Click the dark mode toggle
-    const toggle = page.getByRole('button', { name: /Switch to (light|dark) mode/i });
-    await toggle.click();
+    // Open user menu and toggle dark mode
+    await page.getByLabel('User menu').click();
+    await page.getByRole('button', { name: /Dark Mode/i }).click();
 
     // Check the html element class
     const htmlClass = await page.locator('html').getAttribute('class');
     const isDark = htmlClass?.includes('dark');
 
-    // Toggle again - should go to the opposite mode
-    await toggle.click();
+    // Toggle again — reopen menu since it closes after each action
+    await page.getByLabel('User menu').click();
+    await page.getByRole('button', { name: /Dark Mode/i }).click();
     const htmlClass2 = await page.locator('html').getAttribute('class');
     const isDark2 = htmlClass2?.includes('dark');
 
@@ -23,14 +24,15 @@ test.describe('Dark Mode', () => {
 
   test('persists dark mode across page reload', async ({ page }) => {
     await page.goto('/');
-    await expect(page.getByPlaceholder('Search applications...')).toBeVisible();
+    await expect(page.getByLabel('Manage sessions')).toBeVisible();
 
     // Determine current state
     const initialClass = await page.locator('html').getAttribute('class');
     const initiallyDark = initialClass?.includes('dark') ?? false;
 
-    // Toggle to opposite state
-    await page.getByRole('button', { name: /Switch to (light|dark) mode/i }).click();
+    // Toggle to opposite state via user menu
+    await page.getByLabel('User menu').click();
+    await page.getByRole('button', { name: /Dark Mode/i }).click();
 
     // Verify it toggled
     const toggledClass = await page.locator('html').getAttribute('class');
@@ -39,7 +41,7 @@ test.describe('Dark Mode', () => {
 
     // Reload the page
     await page.reload();
-    await expect(page.getByPlaceholder('Search applications...')).toBeVisible();
+    await expect(page.getByLabel('Manage sessions')).toBeVisible();
 
     // Verify persisted state
     const afterReloadClass = await page.locator('html').getAttribute('class');
@@ -49,10 +51,11 @@ test.describe('Dark Mode', () => {
 
   test('stores preference in localStorage', async ({ page }) => {
     await page.goto('/');
-    await expect(page.getByPlaceholder('Search applications...')).toBeVisible();
+    await expect(page.getByLabel('Manage sessions')).toBeVisible();
 
-    // Toggle dark mode
-    await page.getByRole('button', { name: /Switch to (light|dark) mode/i }).click();
+    // Toggle dark mode via user menu
+    await page.getByLabel('User menu').click();
+    await page.getByRole('button', { name: /Dark Mode/i }).click();
 
     // Check localStorage
     const theme = await page.evaluate(() => localStorage.getItem('sortie-theme'));

--- a/web/e2e/dashboard.spec.ts
+++ b/web/e2e/dashboard.spec.ts
@@ -30,26 +30,37 @@ test.describe('Dashboard', () => {
 
   test('displays app cards', async ({ page }) => {
     await page.goto('/');
-    await expect(page.getByPlaceholder('Search applications...')).toBeVisible();
+    await expect(page.getByLabel('Manage sessions')).toBeVisible();
 
     for (const app of TEST_APPS) {
       await expect(page.getByText(app.name)).toBeVisible();
     }
   });
 
-  test('filters apps by search', async ({ page }) => {
+  test('filters apps by search via command palette', async ({ page }) => {
     await page.goto('/');
-    await expect(page.getByPlaceholder('Search applications...')).toBeVisible();
+    await expect(page.getByLabel('Manage sessions')).toBeVisible();
 
-    await page.getByPlaceholder('Search applications...').fill('App One');
-    await expect(page.getByText('Test App One')).toBeVisible();
-    await expect(page.getByText('Test App Two')).not.toBeVisible();
-    await expect(page.getByText('Test App Three')).not.toBeVisible();
+    // Open command palette with keyboard shortcut
+    await page.keyboard.press('Control+k');
+    const palette = page.locator('[role="listbox"]');
+    await expect(palette).toBeVisible();
+
+    // Type search query
+    await page.getByPlaceholder('Search apps and actions...').fill('App One');
+
+    // Only matching app should appear in palette results
+    await expect(palette.getByText('Test App One')).toBeVisible();
+    await expect(palette.getByText('Test App Two')).not.toBeVisible();
+    await expect(palette.getByText('Test App Three')).not.toBeVisible();
+
+    // Close palette
+    await page.keyboard.press('Escape');
   });
 
   test('filters apps by category', async ({ page }) => {
     await page.goto('/');
-    await expect(page.getByPlaceholder('Search applications...')).toBeVisible();
+    await expect(page.getByLabel('Manage sessions')).toBeVisible();
 
     // Click the Productivity category filter pill (rounded-full buttons)
     await page.locator('button.rounded-full', { hasText: /Productivity/ }).click();
@@ -82,9 +93,16 @@ test.describe('Dashboard', () => {
 
   test('shows empty state for unmatched search', async ({ page }) => {
     await page.goto('/');
-    await expect(page.getByPlaceholder('Search applications...')).toBeVisible();
+    await expect(page.getByLabel('Manage sessions')).toBeVisible();
 
-    await page.getByPlaceholder('Search applications...').fill('xyznonexistent');
-    await expect(page.getByText('No applications found')).toBeVisible();
+    // Open command palette
+    await page.keyboard.press('Control+k');
+    await expect(page.getByPlaceholder('Search apps and actions...')).toBeVisible();
+
+    await page.getByPlaceholder('Search apps and actions...').fill('xyznonexistent');
+    await expect(page.getByText('No results found')).toBeVisible();
+
+    // Close palette
+    await page.keyboard.press('Escape');
   });
 });

--- a/web/e2e/sessions.spec.ts
+++ b/web/e2e/sessions.spec.ts
@@ -31,7 +31,7 @@ test.describe('Sessions', () => {
 
   test('launches a container session and shows status transitions', async ({ page }) => {
     await page.goto('/');
-    await expect(page.getByPlaceholder('Search applications...')).toBeVisible();
+    await expect(page.getByLabel('Manage sessions')).toBeVisible();
 
     // Click the container app card
     await page.getByText('Test Container App').click();
@@ -57,7 +57,7 @@ test.describe('Sessions', () => {
 
     // Go back to dashboard
     await page.getByLabel('Back to dashboard').click();
-    await expect(page.getByPlaceholder('Search applications...')).toBeVisible();
+    await expect(page.getByLabel('Manage sessions')).toBeVisible();
   });
 
   test('shows session in session manager after launch', async ({ page, request }) => {
@@ -68,7 +68,7 @@ test.describe('Sessions', () => {
     await waitForSessionRunning(request, token, session.id);
 
     await page.goto('/');
-    await expect(page.getByPlaceholder('Search applications...')).toBeVisible();
+    await expect(page.getByLabel('Manage sessions')).toBeVisible();
 
     // Open session manager
     await page.getByLabel('Manage sessions').click();
@@ -94,7 +94,7 @@ test.describe('Sessions', () => {
     await waitForSessionRunning(request, token, session.id);
 
     await page.goto('/');
-    await expect(page.getByPlaceholder('Search applications...')).toBeVisible();
+    await expect(page.getByLabel('Manage sessions')).toBeVisible();
 
     // Open session manager
     await page.getByLabel('Manage sessions').click();
@@ -120,10 +120,11 @@ test.describe('Sessions', () => {
     await waitForSessionRunning(request, token, session.id);
 
     await page.goto('/');
-    await expect(page.getByPlaceholder('Search applications...')).toBeVisible();
+    await expect(page.getByLabel('Manage sessions')).toBeVisible();
 
-    // Open admin panel
-    await page.getByRole('button', { name: /Admin settings/i }).click();
+    // Open admin panel via user menu
+    await page.getByLabel('User menu').click();
+    await page.getByRole('button', { name: 'Admin Panel' }).click();
     await expect(page.getByRole('heading', { name: 'Admin Settings' })).toBeVisible();
 
     // Click Sessions tab
@@ -153,7 +154,7 @@ test.describe('Sessions', () => {
     await waitForSessionRunning(request, token, session.id);
 
     await page.goto('/');
-    await expect(page.getByPlaceholder('Search applications...')).toBeVisible();
+    await expect(page.getByLabel('Manage sessions')).toBeVisible();
 
     // The sessions button should show a green badge with a numeric count.
     // Note: parallel browser workers share the server, so the count may be > 1.
@@ -166,7 +167,7 @@ test.describe('Sessions', () => {
 
     // Reload to see updated state
     await page.reload();
-    await expect(page.getByPlaceholder('Search applications...')).toBeVisible();
+    await expect(page.getByLabel('Manage sessions')).toBeVisible();
 
     // Badge count should decrease (may still be visible if other browser workers have sessions)
     // Just verify the page loaded correctly after termination
@@ -176,7 +177,7 @@ test.describe('Sessions', () => {
     page,
   }) => {
     await page.goto('/');
-    await expect(page.getByPlaceholder('Search applications...')).toBeVisible();
+    await expect(page.getByLabel('Manage sessions')).toBeVisible();
 
     // Click the container app card to open session page
     await page.getByText('Test Container App').click();
@@ -196,7 +197,7 @@ test.describe('Sessions', () => {
 
     // Click back to dashboard (this auto-terminates the session)
     await page.getByLabel('Back to dashboard').click();
-    await expect(page.getByPlaceholder('Search applications...')).toBeVisible();
+    await expect(page.getByLabel('Manage sessions')).toBeVisible();
 
     // Verify we returned to the dashboard successfully.
     // The afterEach cleanup handles any sessions not auto-terminated.

--- a/web/src/components/CommandPalette.tsx
+++ b/web/src/components/CommandPalette.tsx
@@ -1,0 +1,350 @@
+import { useState, useEffect, useRef, useCallback } from 'react';
+import type { Application } from '../types';
+
+interface CommandPaletteProps {
+  isOpen: boolean;
+  onClose: () => void;
+  apps: Application[];
+  isAdmin: boolean;
+  darkMode: boolean;
+  onLaunchApp: (app: Application) => void;
+  onOpenTemplates: () => void;
+  onToggleDarkMode: () => void;
+  onOpenAdmin: () => void;
+  onOpenAuditLog: () => void;
+}
+
+interface PaletteItem {
+  id: string;
+  label: string;
+  description?: string;
+  icon: React.ReactNode;
+  section: string;
+  onSelect: () => void;
+}
+
+export function CommandPalette({
+  isOpen,
+  onClose,
+  apps,
+  isAdmin,
+  darkMode,
+  onLaunchApp,
+  onOpenTemplates,
+  onToggleDarkMode,
+  onOpenAdmin,
+  onOpenAuditLog,
+}: CommandPaletteProps) {
+  const [query, setQuery] = useState('');
+  const [selectedIndex, setSelectedIndex] = useState(0);
+  const inputRef = useRef<HTMLInputElement>(null);
+  const listRef = useRef<HTMLDivElement>(null);
+  const previousFocusRef = useRef<HTMLElement | null>(null);
+
+  const buildItems = useCallback((): PaletteItem[] => {
+    const q = query.toLowerCase();
+    const items: PaletteItem[] = [];
+
+    // Applications section
+    const matchedApps = query
+      ? apps.filter(
+          (app) =>
+            app.name.toLowerCase().includes(q) ||
+            app.description.toLowerCase().includes(q) ||
+            app.category.toLowerCase().includes(q)
+        )
+      : apps.slice(0, 5);
+
+    matchedApps.forEach((app) => {
+      items.push({
+        id: `app-${app.id}`,
+        label: app.name,
+        description: app.description,
+        section: 'Applications',
+        icon: (
+          <img
+            src={app.icon}
+            alt=""
+            className="w-5 h-5 object-contain"
+            onError={(e) => {
+              (e.target as HTMLImageElement).style.display = 'none';
+              (e.target as HTMLImageElement).nextElementSibling?.classList.remove('hidden');
+            }}
+          />
+        ),
+        onSelect: () => onLaunchApp(app),
+      });
+    });
+
+    // Actions section
+    const actions: PaletteItem[] = [
+      {
+        id: 'action-templates',
+        label: 'Browse Templates',
+        description: 'Add pre-configured applications',
+        section: 'Actions',
+        icon: (
+          <svg className="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+            <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M4 5a1 1 0 011-1h14a1 1 0 011 1v2a1 1 0 01-1 1H5a1 1 0 01-1-1V5zM4 13a1 1 0 011-1h6a1 1 0 011 1v6a1 1 0 01-1 1H5a1 1 0 01-1-1v-6zM16 13a1 1 0 011-1h2a1 1 0 011 1v6a1 1 0 01-1 1h-2a1 1 0 01-1-1v-6z" />
+          </svg>
+        ),
+        onSelect: onOpenTemplates,
+      },
+      {
+        id: 'action-darkmode',
+        label: darkMode ? 'Switch to Light Mode' : 'Switch to Dark Mode',
+        description: 'Toggle appearance',
+        section: 'Actions',
+        icon: darkMode ? (
+          <svg className="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+            <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M12 3v1m0 16v1m9-9h-1M4 12H3m15.364 6.364l-.707-.707M6.343 6.343l-.707-.707m12.728 0l-.707.707M6.343 17.657l-.707.707M16 12a4 4 0 11-8 0 4 4 0 018 0z" />
+          </svg>
+        ) : (
+          <svg className="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+            <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M20.354 15.354A9 9 0 018.646 3.646 9.003 9.003 0 0012 21a9.003 9.003 0 008.354-5.646z" />
+          </svg>
+        ),
+        onSelect: onToggleDarkMode,
+      },
+      {
+        id: 'action-docs',
+        label: 'Documentation',
+        description: 'Open docs in new tab',
+        section: 'Actions',
+        icon: (
+          <svg className="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+            <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M12 6.253v13m0-13C10.832 5.477 9.246 5 7.5 5S4.168 5.477 3 6.253v13C4.168 18.477 5.754 18 7.5 18s3.332.477 4.5 1.253m0-13C13.168 5.477 14.754 5 16.5 5c1.747 0 3.332.477 4.5 1.253v13C19.832 18.477 18.247 18 16.5 18c-1.746 0-3.332.477-4.5 1.253" />
+          </svg>
+        ),
+        onSelect: () => window.open('/docs/', '_blank', 'noopener,noreferrer'),
+      },
+    ];
+
+    const filteredActions = query
+      ? actions.filter((a) => a.label.toLowerCase().includes(q) || a.description?.toLowerCase().includes(q))
+      : actions;
+
+    items.push(...filteredActions);
+
+    // Admin section
+    if (isAdmin) {
+      const adminItems: PaletteItem[] = [
+        {
+          id: 'admin-panel',
+          label: 'Admin Panel',
+          description: 'Manage users and applications',
+          section: 'Admin',
+          icon: (
+            <svg className="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M10.325 4.317c.426-1.756 2.924-1.756 3.35 0a1.724 1.724 0 002.573 1.066c1.543-.94 3.31.826 2.37 2.37a1.724 1.724 0 001.065 2.572c1.756.426 1.756 2.924 0 3.35a1.724 1.724 0 00-1.066 2.573c.94 1.543-.826 3.31-2.37 2.37a1.724 1.724 0 00-2.572 1.065c-.426 1.756-2.924 1.756-3.35 0a1.724 1.724 0 00-2.573-1.066c-1.543.94-3.31-.826-2.37-2.37a1.724 1.724 0 00-1.065-2.572c-1.756-.426-1.756-2.924 0-3.35a1.724 1.724 0 001.066-2.573c-.94-1.543.826-3.31 2.37-2.37.996.608 2.296.07 2.572-1.065z" />
+              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M15 12a3 3 0 11-6 0 3 3 0 016 0z" />
+            </svg>
+          ),
+          onSelect: onOpenAdmin,
+        },
+        {
+          id: 'admin-audit',
+          label: 'Audit Log',
+          description: 'View system audit trail',
+          section: 'Admin',
+          icon: (
+            <svg className="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M9 12h6m-6 4h6m2 5H7a2 2 0 01-2-2V5a2 2 0 012-2h5.586a1 1 0 01.707.293l5.414 5.414a1 1 0 01.293.707V19a2 2 0 01-2 2z" />
+            </svg>
+          ),
+          onSelect: onOpenAuditLog,
+        },
+      ];
+
+      const filteredAdmin = query
+        ? adminItems.filter((a) => a.label.toLowerCase().includes(q) || a.description?.toLowerCase().includes(q))
+        : adminItems;
+
+      items.push(...filteredAdmin);
+    }
+
+    return items;
+  }, [query, apps, isAdmin, darkMode, onLaunchApp, onOpenTemplates, onToggleDarkMode, onOpenAdmin, onOpenAuditLog]);
+
+  const items = buildItems();
+
+  // Reset selection when query changes
+  useEffect(() => {
+    setSelectedIndex(0);
+  }, [query]);
+
+  // Focus input on open, restore focus on close
+  useEffect(() => {
+    if (isOpen) {
+      previousFocusRef.current = document.activeElement as HTMLElement;
+      // Small delay to allow animation to start
+      requestAnimationFrame(() => inputRef.current?.focus());
+    } else {
+      setQuery('');
+      setSelectedIndex(0);
+      previousFocusRef.current?.focus();
+    }
+  }, [isOpen]);
+
+  // Scroll selected item into view
+  useEffect(() => {
+    if (!listRef.current) return;
+    const selected = listRef.current.querySelector('[data-selected="true"]');
+    selected?.scrollIntoView({ block: 'nearest' });
+  }, [selectedIndex]);
+
+  // Global Escape handler — works regardless of focus position
+  useEffect(() => {
+    if (!isOpen) return;
+    const handler = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') {
+        e.preventDefault();
+        onClose();
+      }
+    };
+    window.addEventListener('keydown', handler);
+    return () => window.removeEventListener('keydown', handler);
+  }, [isOpen, onClose]);
+
+  const handleKeyDown = (e: React.KeyboardEvent) => {
+    switch (e.key) {
+      case 'ArrowDown':
+        e.preventDefault();
+        setSelectedIndex((prev) => (prev < items.length - 1 ? prev + 1 : 0));
+        break;
+      case 'ArrowUp':
+        e.preventDefault();
+        setSelectedIndex((prev) => (prev > 0 ? prev - 1 : items.length - 1));
+        break;
+      case 'Enter':
+        e.preventDefault();
+        if (items[selectedIndex]) {
+          items[selectedIndex].onSelect();
+          onClose();
+        }
+        break;
+    }
+  };
+
+  if (!isOpen) return null;
+
+  // Group items by section for rendering
+  const sections: { name: string; items: (PaletteItem & { flatIndex: number })[] }[] = [];
+  let flatIndex = 0;
+  items.forEach((item) => {
+    let section = sections.find((s) => s.name === item.section);
+    if (!section) {
+      section = { name: item.section, items: [] };
+      sections.push(section);
+    }
+    section.items.push({ ...item, flatIndex: flatIndex++ });
+  });
+
+  return (
+    <div className="fixed inset-0 z-50" onKeyDown={handleKeyDown}>
+      {/* Backdrop */}
+      <div
+        className="absolute inset-0 bg-black/30 backdrop-blur-sm"
+        onClick={onClose}
+      />
+
+      {/* Modal */}
+      <div className="relative flex justify-center" style={{ paddingTop: '15vh' }}>
+        <div className="w-full max-w-xl mx-4 bg-white dark:bg-gray-800 rounded-2xl shadow-2xl border border-gray-200 dark:border-gray-700 overflow-hidden animate-palette-in">
+          {/* Search bar */}
+          <div className="flex items-center gap-3 px-4 py-3 border-b border-gray-200 dark:border-gray-700">
+            <svg className="w-5 h-5 text-gray-400 flex-shrink-0" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M21 21l-6-6m2-5a7 7 0 11-14 0 7 7 0 0114 0z" />
+            </svg>
+            <input
+              ref={inputRef}
+              type="text"
+              placeholder="Search apps and actions..."
+              value={query}
+              onChange={(e) => setQuery(e.target.value)}
+              className="flex-1 bg-transparent text-gray-900 dark:text-gray-100 placeholder-gray-400 dark:placeholder-gray-500 outline-none text-sm"
+            />
+            <kbd className="hidden sm:inline-flex items-center px-1.5 py-0.5 text-[10px] font-medium text-gray-400 dark:text-gray-500 bg-gray-100 dark:bg-gray-700 rounded border border-gray-200 dark:border-gray-600">
+              ESC
+            </kbd>
+          </div>
+
+          {/* Results */}
+          <div ref={listRef} className="max-h-80 overflow-y-auto" role="listbox">
+            {items.length === 0 ? (
+              <div className="px-4 py-8 text-center text-sm text-gray-500 dark:text-gray-400">
+                No results found
+              </div>
+            ) : (
+              sections.map((section) => (
+                <div key={section.name}>
+                  <div className="px-4 pt-3 pb-1">
+                    <span className="text-[11px] font-semibold text-gray-400 dark:text-gray-500 uppercase tracking-wider">
+                      {section.name}
+                    </span>
+                  </div>
+                  {section.items.map((item) => (
+                    <button
+                      key={item.id}
+                      role="option"
+                      aria-selected={item.flatIndex === selectedIndex}
+                      data-selected={item.flatIndex === selectedIndex}
+                      className={`w-full flex items-center gap-3 px-4 py-2.5 text-left transition-colors ${
+                        item.flatIndex === selectedIndex
+                          ? 'bg-brand-accent/10 dark:bg-brand-accent/20 text-brand-accent'
+                          : 'text-gray-700 dark:text-gray-300 hover:bg-gray-50 dark:hover:bg-gray-700/50'
+                      }`}
+                      onClick={() => {
+                        item.onSelect();
+                        onClose();
+                      }}
+                      onMouseEnter={() => setSelectedIndex(item.flatIndex)}
+                    >
+                      <div className={`w-8 h-8 flex items-center justify-center rounded-lg flex-shrink-0 ${
+                        item.flatIndex === selectedIndex
+                          ? 'bg-brand-accent/10 dark:bg-brand-accent/20'
+                          : 'bg-gray-100 dark:bg-gray-700'
+                      }`}>
+                        {item.icon}
+                        {/* Fallback initial for app icons */}
+                        {item.section === 'Applications' && (
+                          <span className="hidden text-xs font-bold text-gray-500 dark:text-gray-400">
+                            {item.label.charAt(0)}
+                          </span>
+                        )}
+                      </div>
+                      <div className="flex-1 min-w-0">
+                        <div className="text-sm font-medium truncate">{item.label}</div>
+                        {item.description && (
+                          <div className="text-xs text-gray-500 dark:text-gray-400 truncate">
+                            {item.description}
+                          </div>
+                        )}
+                      </div>
+                    </button>
+                  ))}
+                </div>
+              ))
+            )}
+          </div>
+
+          {/* Footer hints */}
+          <div className="flex items-center gap-4 px-4 py-2.5 border-t border-gray-200 dark:border-gray-700 text-[11px] text-gray-400 dark:text-gray-500">
+            <span className="flex items-center gap-1">
+              <kbd className="px-1 py-0.5 bg-gray-100 dark:bg-gray-700 rounded border border-gray-200 dark:border-gray-600 font-mono">&#8593;&#8595;</kbd>
+              navigate
+            </span>
+            <span className="flex items-center gap-1">
+              <kbd className="px-1 py-0.5 bg-gray-100 dark:bg-gray-700 rounded border border-gray-200 dark:border-gray-600 font-mono">&#9166;</kbd>
+              select
+            </span>
+            <span className="flex items-center gap-1">
+              <kbd className="px-1 py-0.5 bg-gray-100 dark:bg-gray-700 rounded border border-gray-200 dark:border-gray-600 font-mono">esc</kbd>
+              close
+            </span>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/web/src/components/UserMenu.tsx
+++ b/web/src/components/UserMenu.tsx
@@ -1,0 +1,175 @@
+import { useState, useEffect, useRef } from 'react';
+import type { User } from '../types';
+
+interface UserMenuProps {
+  user: User;
+  isAdmin: boolean;
+  darkMode: boolean;
+  onToggleDarkMode: () => void;
+  onOpenDocs: () => void;
+  onOpenAdmin: () => void;
+  onOpenAuditLog: () => void;
+  onLogout: () => void;
+}
+
+export function UserMenu({
+  user,
+  isAdmin,
+  darkMode,
+  onToggleDarkMode,
+  onOpenDocs,
+  onOpenAdmin,
+  onOpenAuditLog,
+  onLogout,
+}: UserMenuProps) {
+  const [isOpen, setIsOpen] = useState(false);
+  const menuRef = useRef<HTMLDivElement>(null);
+
+  const displayName = user.displayName || user.username;
+  const initial = displayName.charAt(0).toUpperCase();
+
+  // Close on click outside
+  useEffect(() => {
+    if (!isOpen) return;
+    const handler = (e: MouseEvent) => {
+      if (menuRef.current && !menuRef.current.contains(e.target as Node)) {
+        setIsOpen(false);
+      }
+    };
+    document.addEventListener('mousedown', handler);
+    return () => document.removeEventListener('mousedown', handler);
+  }, [isOpen]);
+
+  // Close on Escape
+  useEffect(() => {
+    if (!isOpen) return;
+    const handler = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') setIsOpen(false);
+    };
+    window.addEventListener('keydown', handler);
+    return () => window.removeEventListener('keydown', handler);
+  }, [isOpen]);
+
+  const handleAction = (action: () => void) => {
+    setIsOpen(false);
+    action();
+  };
+
+  return (
+    <div ref={menuRef} className="relative">
+      {/* Avatar trigger */}
+      <button
+        onClick={() => setIsOpen((prev) => !prev)}
+        className="w-9 h-9 rounded-full bg-brand-accent text-white font-semibold text-sm flex items-center justify-center hover:ring-2 hover:ring-white/30 transition-all"
+        aria-label="User menu"
+        aria-expanded={isOpen}
+      >
+        {initial}
+      </button>
+
+      {/* Dropdown */}
+      {isOpen && (
+        <div className="absolute right-0 mt-2 w-64 bg-white dark:bg-gray-800 rounded-xl shadow-xl border border-gray-200 dark:border-gray-700 overflow-hidden animate-dropdown-in z-50">
+          {/* User info */}
+          <div className="px-4 py-3 border-b border-gray-100 dark:border-gray-700">
+            <div className="font-medium text-sm text-gray-900 dark:text-gray-100">{displayName}</div>
+            <div className="text-xs text-gray-500 dark:text-gray-400">@{user.username}</div>
+            <span className={`mt-1.5 inline-flex items-center text-[10px] font-medium px-2 py-0.5 rounded-full ${
+              isAdmin
+                ? 'bg-brand-accent/10 text-brand-accent dark:bg-brand-accent/20'
+                : 'bg-gray-100 text-gray-600 dark:bg-gray-700 dark:text-gray-400'
+            }`}>
+              {isAdmin ? 'Admin' : 'User'}
+            </span>
+          </div>
+
+          {/* Actions */}
+          <div className="py-1">
+            {/* Dark Mode toggle */}
+            <button
+              onClick={() => handleAction(onToggleDarkMode)}
+              className="w-full flex items-center justify-between px-4 py-2.5 text-sm text-gray-700 dark:text-gray-300 hover:bg-gray-50 dark:hover:bg-gray-700/50 transition-colors"
+            >
+              <div className="flex items-center gap-3">
+                {darkMode ? (
+                  <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                    <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M12 3v1m0 16v1m9-9h-1M4 12H3m15.364 6.364l-.707-.707M6.343 6.343l-.707-.707m12.728 0l-.707.707M6.343 17.657l-.707.707M16 12a4 4 0 11-8 0 4 4 0 018 0z" />
+                  </svg>
+                ) : (
+                  <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                    <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M20.354 15.354A9 9 0 018.646 3.646 9.003 9.003 0 0012 21a9.003 9.003 0 008.354-5.646z" />
+                  </svg>
+                )}
+                <span>Dark Mode</span>
+              </div>
+              {/* Toggle indicator */}
+              <div className={`w-8 h-4.5 rounded-full flex items-center px-0.5 transition-colors ${
+                darkMode ? 'bg-brand-accent' : 'bg-gray-300 dark:bg-gray-600'
+              }`}>
+                <div className={`w-3.5 h-3.5 rounded-full bg-white shadow-sm transition-transform ${
+                  darkMode ? 'translate-x-3.5' : 'translate-x-0'
+                }`} />
+              </div>
+            </button>
+
+            {/* Documentation */}
+            <button
+              onClick={() => handleAction(onOpenDocs)}
+              className="w-full flex items-center gap-3 px-4 py-2.5 text-sm text-gray-700 dark:text-gray-300 hover:bg-gray-50 dark:hover:bg-gray-700/50 transition-colors"
+            >
+              <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M12 6.253v13m0-13C10.832 5.477 9.246 5 7.5 5S4.168 5.477 3 6.253v13C4.168 18.477 5.754 18 7.5 18s3.332.477 4.5 1.253m0-13C13.168 5.477 14.754 5 16.5 5c1.747 0 3.332.477 4.5 1.253v13C19.832 18.477 18.247 18 16.5 18c-1.746 0-3.332.477-4.5 1.253" />
+              </svg>
+              <span>Documentation</span>
+              <svg className="w-3 h-3 ml-auto text-gray-400" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M10 6H6a2 2 0 00-2 2v10a2 2 0 002 2h10a2 2 0 002-2v-4M14 4h6m0 0v6m0-6L10 14" />
+              </svg>
+            </button>
+          </div>
+
+          {/* Admin section */}
+          {isAdmin && (
+            <>
+              <div className="border-t border-gray-100 dark:border-gray-700" />
+              <div className="py-1">
+                <button
+                  onClick={() => handleAction(onOpenAdmin)}
+                  className="w-full flex items-center gap-3 px-4 py-2.5 text-sm text-gray-700 dark:text-gray-300 hover:bg-gray-50 dark:hover:bg-gray-700/50 transition-colors"
+                >
+                  <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                    <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M10.325 4.317c.426-1.756 2.924-1.756 3.35 0a1.724 1.724 0 002.573 1.066c1.543-.94 3.31.826 2.37 2.37a1.724 1.724 0 001.065 2.572c1.756.426 1.756 2.924 0 3.35a1.724 1.724 0 00-1.066 2.573c.94 1.543-.826 3.31-2.37 2.37a1.724 1.724 0 00-2.572 1.065c-.426 1.756-2.924 1.756-3.35 0a1.724 1.724 0 00-2.573-1.066c-1.543.94-3.31-.826-2.37-2.37a1.724 1.724 0 00-1.065-2.572c-1.756-.426-1.756-2.924 0-3.35a1.724 1.724 0 001.066-2.573c-.94-1.543.826-3.31 2.37-2.37.996.608 2.296.07 2.572-1.065z" />
+                    <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M15 12a3 3 0 11-6 0 3 3 0 016 0z" />
+                  </svg>
+                  <span>Admin Panel</span>
+                </button>
+                <button
+                  onClick={() => handleAction(onOpenAuditLog)}
+                  className="w-full flex items-center gap-3 px-4 py-2.5 text-sm text-gray-700 dark:text-gray-300 hover:bg-gray-50 dark:hover:bg-gray-700/50 transition-colors"
+                >
+                  <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                    <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M9 12h6m-6 4h6m2 5H7a2 2 0 01-2-2V5a2 2 0 012-2h5.586a1 1 0 01.707.293l5.414 5.414a1 1 0 01.293.707V19a2 2 0 01-2 2z" />
+                  </svg>
+                  <span>Audit Log</span>
+                </button>
+              </div>
+            </>
+          )}
+
+          {/* Sign out */}
+          <div className="border-t border-gray-100 dark:border-gray-700" />
+          <div className="py-1">
+            <button
+              onClick={() => handleAction(onLogout)}
+              className="w-full flex items-center gap-3 px-4 py-2.5 text-sm text-red-600 dark:text-red-400 hover:bg-red-50 dark:hover:bg-red-900/20 transition-colors"
+            >
+              <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M17 16l4-4m0 0l-4-4m4 4H7m6 4v1a3 3 0 01-3 3H6a3 3 0 01-3-3V7a3 3 0 013-3h4a3 3 0 013 3v1" />
+              </svg>
+              <span>Sign Out</span>
+            </button>
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/web/src/index.css
+++ b/web/src/index.css
@@ -57,6 +57,22 @@ body {
   animation: fade-in-up 0.4s ease-out both;
 }
 
+@keyframes palette-in {
+  from { opacity: 0; transform: translateY(-8px) scale(0.98); }
+  to { opacity: 1; transform: translateY(0) scale(1); }
+}
+.animate-palette-in {
+  animation: palette-in 0.15s ease-out both;
+}
+
+@keyframes dropdown-in {
+  from { opacity: 0; transform: translateY(-4px); }
+  to { opacity: 1; transform: translateY(0); }
+}
+.animate-dropdown-in {
+  animation: dropdown-in 0.12s ease-out both;
+}
+
 /* Dark mode support */
 .dark {
   color-scheme: dark;


### PR DESCRIPTION
## Summary
- Replace 8+ header buttons with a minimal 3-element layout: logo, sessions button (with active count badge), and user avatar
- Add `Cmd/Ctrl+K` command palette for searching apps and navigating to actions (templates, dark mode, docs, admin, audit log)
- Add avatar dropdown menu with user info, role badge, dark mode toggle, docs link, admin items (conditional), and sign out
- Update all e2e tests to use new UI entry points (command palette search, user menu for admin/dark mode/logout)

## Test plan
- [x] `npm --prefix web run build` passes
- [x] All 29 Chromium e2e tests pass
- [x] All 85 cross-browser tests pass (Chromium + Firefox + WebKit)
- [ ] Manual: verify `Cmd+K` opens palette, search filters apps, arrow keys navigate, Enter launches, Escape closes
- [ ] Manual: verify avatar dropdown shows user info, dark mode toggle, admin items for admin users, sign out
- [ ] Manual: responsive — search hint hides on mobile, header stays clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)