### PR TITLE
Build and push sidecar images to GHCR, fix E2E sidecar config

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -5,6 +5,10 @@ on:
     branches: [main]
   workflow_dispatch:
 
+permissions:
+  contents: read
+  packages: write
+
 env:
   GO_VERSION: "1.24"
   NODE_VERSION: "22"
@@ -42,8 +46,29 @@ jobs:
       - name: Install Helm
         uses: azure/setup-helm@v4
 
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Log in to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
       - name: Build application
         run: make build
+
+      - name: Build and push sidecar images
+        run: |
+          COMMIT_SHA="${GITHUB_SHA::7}"
+          for sidecar in vnc-sidecar browser-sidecar guacd-sidecar; do
+            docker buildx build \
+              --push \
+              --tag ghcr.io/rjsadow/sortie-${sidecar}:latest \
+              --tag ghcr.io/rjsadow/sortie-${sidecar}:sha-${COMMIT_SHA} \
+              docker/${sidecar}
+          done
 
       - name: Setup E2E cluster
         run: ./scripts/ci-e2e.sh setup

--- a/charts/sortie/templates/configmap.yaml
+++ b/charts/sortie/templates/configmap.yaml
@@ -13,4 +13,5 @@ data:
   SORTIE_SESSION_CLEANUP_INTERVAL: {{ .Values.session.cleanupInterval | quote }}
   SORTIE_POD_READY_TIMEOUT: {{ .Values.session.podReadyTimeout | quote }}
   SORTIE_VNC_SIDECAR_IMAGE: {{ .Values.vncSidecar.image | quote }}
+  SORTIE_BROWSER_SIDECAR_IMAGE: {{ .Values.browserSidecar.image | quote }}
   SORTIE_GUACD_SIDECAR_IMAGE: {{ .Values.guacdSidecar.image | quote }}

--- a/charts/sortie/values.yaml
+++ b/charts/sortie/values.yaml
@@ -13,6 +13,10 @@ image:
 vncSidecar:
   image: ghcr.io/rjsadow/sortie-vnc-sidecar:latest
 
+# Browser sidecar image for web_proxy sessions
+browserSidecar:
+  image: ghcr.io/rjsadow/sortie-browser-sidecar:latest
+
 # Guacd sidecar image for Windows RDP sessions
 guacdSidecar:
   image: guacamole/guacd:1.5.5

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -29,8 +29,9 @@ type Config struct {
 	// Kubernetes configuration
 	Namespace          string
 	Kubeconfig         string
-	VNCSidecarImage    string
-	GuacdSidecarImage  string
+	VNCSidecarImage      string
+	BrowserSidecarImage  string
+	GuacdSidecarImage    string
 
 	// Session configuration
 	SessionTimeout         time.Duration
@@ -117,6 +118,7 @@ const (
 	DefaultTenantName             = "Sortie"
 	DefaultNamespace              = "default"
 	DefaultVNCSidecarImage        = "ghcr.io/rjsadow/sortie-vnc-sidecar:latest"
+	DefaultBrowserSidecarImage    = "ghcr.io/rjsadow/sortie-browser-sidecar:latest"
 	DefaultGuacdSidecarImage      = "guacamole/guacd:1.5.5"
 	DefaultSessionTimeout         = 2 * time.Hour
 	DefaultSessionCleanupInterval = 5 * time.Minute
@@ -156,8 +158,9 @@ func Load() (*Config, error) {
 
 		// Kubernetes defaults
 		Namespace:         DefaultNamespace,
-		VNCSidecarImage:   DefaultVNCSidecarImage,
-		GuacdSidecarImage: DefaultGuacdSidecarImage,
+		VNCSidecarImage:     DefaultVNCSidecarImage,
+		BrowserSidecarImage: DefaultBrowserSidecarImage,
+		GuacdSidecarImage:   DefaultGuacdSidecarImage,
 
 		// Session defaults
 		SessionTimeout:         DefaultSessionTimeout,
@@ -259,6 +262,10 @@ func (c *Config) loadFromEnv() error {
 
 	if v := os.Getenv("SORTIE_VNC_SIDECAR_IMAGE"); v != "" {
 		c.VNCSidecarImage = v
+	}
+
+	if v := os.Getenv("SORTIE_BROWSER_SIDECAR_IMAGE"); v != "" {
+		c.BrowserSidecarImage = v
 	}
 
 	if v := os.Getenv("SORTIE_GUACD_SIDECAR_IMAGE"); v != "" {

--- a/main.go
+++ b/main.go
@@ -61,6 +61,7 @@ func main() {
 	// Initialize Kubernetes configuration (skip when using mock runner)
 	if !*mockRunnerFlag {
 		k8s.Configure(appConfig.Namespace, appConfig.Kubeconfig, appConfig.VNCSidecarImage)
+		k8s.ConfigureBrowserSidecar(appConfig.BrowserSidecarImage)
 		k8s.ConfigureGuacdSidecar(appConfig.GuacdSidecarImage)
 	}
 

--- a/scripts/ci-e2e.sh
+++ b/scripts/ci-e2e.sh
@@ -70,6 +70,12 @@ setup() {
         kind load docker-image ghcr.io/rjsadow/sortie-browser-sidecar:e2e --name "$CLUSTER_NAME"
     fi
 
+    # Build guacd sidecar
+    if [ -d "${ROOT_DIR}/docker/guacd-sidecar" ]; then
+        docker build -t ghcr.io/rjsadow/sortie-guacd-sidecar:e2e "${ROOT_DIR}/docker/guacd-sidecar"
+        kind load docker-image ghcr.io/rjsadow/sortie-guacd-sidecar:e2e --name "$CLUSTER_NAME"
+    fi
+
     log_info "Deploying Sortie via Helm..."
     helm upgrade --install sortie "${ROOT_DIR}/charts/sortie" \
         --namespace "$NAMESPACE" \
@@ -77,6 +83,9 @@ setup() {
         --set image.repository=ghcr.io/rjsadow/sortie \
         --set image.tag=e2e \
         --set image.pullPolicy=Never \
+        --set vncSidecar.image=ghcr.io/rjsadow/sortie-vnc-sidecar:e2e \
+        --set browserSidecar.image=ghcr.io/rjsadow/sortie-browser-sidecar:e2e \
+        --set guacdSidecar.image=ghcr.io/rjsadow/sortie-guacd-sidecar:e2e \
         --wait --timeout 180s
 
     log_info "Starting port-forward on localhost:${PORT_FORWARD_PORT}..."


### PR DESCRIPTION
The E2E tests fail on every merge because sidecar images don't exist on GHCR and the Helm deploy doesn't override sidecar image references, causing ImagePullBackOff. Additionally, the browser sidecar image was not configurable via Helm/config at all.

- Add GHCR login and build+push steps to E2E workflow for all 3 sidecars
- Add guacd sidecar build/load to ci-e2e.sh (was missing)
- Add --set flags for sidecar image overrides in E2E Helm deploy
- Wire browser sidecar image through Helm chart, config, and main.go