### PR TITLE
Fix: RDP share links and modal keyboard input

### DIFF
--- a/web/src/components/GuacamoleViewer.tsx
+++ b/web/src/components/GuacamoleViewer.tsx
@@ -187,7 +187,7 @@ export function GuacamoleViewer({
             client.sendMouseState(mouseState);
           };
 
-          const keyboard = new Guacamole.Keyboard(document);
+          const keyboard = new Guacamole.Keyboard(containerRef.current);
           keyboard.onkeydown = (keysym: number) => {
             client.sendKeyEvent(1, keysym);
           };


### PR DESCRIPTION
## Summary
- **Share links now work**: When a user navigates to `/session/{id}?share_token={token}`, the frontend parses the URL, calls the join endpoint, and opens the shared session with correct permissions (view-only/full access)
- **Modal input fixed**: Keyboard input in the session sharing modal was being intercepted by the Guacamole RDP viewer. Scoped the keyboard handler to the viewer container instead of `document`

## Test plan
- [ ] Generate a share link from an RDP session, open it in another browser/user — session should open with the shared desktop visible
- [ ] Share link works for multiple users (not just the first)
- [ ] Open the share dialog over an RDP session — typing in the username field should work normally
- [ ] After closing the modal, keyboard input to the RDP session still works (click viewer to refocus)
- [ ] VNC sessions unaffected by these changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)