### PR TITLE
Add session recording documentation

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -102,6 +102,38 @@ SORTIE_DEFAULT_MEM_LIMIT=2Gi
 # SORTIE_RECORDING_BUFFER_SIZE=0
 
 # =============================================================================
+# Video Recording Configuration
+# =============================================================================
+
+# Enable client-side video recording of container sessions (default: false)
+# When enabled, users can record sessions as .webm video files.
+# SORTIE_VIDEO_RECORDING_ENABLED=false
+
+# Storage backend for recordings: "local" or "s3" (default: local)
+# SORTIE_RECORDING_STORAGE_BACKEND=local
+
+# Local filesystem path for recording storage (default: /data/recordings)
+# SORTIE_RECORDING_STORAGE_PATH=/data/recordings
+
+# Maximum recording upload size in MB (default: 500)
+# SORTIE_RECORDING_MAX_SIZE_MB=500
+
+# Days to retain recordings before automatic cleanup (default: 0 = keep forever)
+# SORTIE_RECORDING_RETENTION_DAYS=0
+
+# S3 bucket name (required when storage backend is "s3")
+# SORTIE_RECORDING_S3_BUCKET=my-recordings-bucket
+
+# AWS region for S3 (default: us-east-1)
+# SORTIE_RECORDING_S3_REGION=us-east-1
+
+# Custom S3 endpoint for MinIO or self-hosted S3-compatible storage
+# SORTIE_RECORDING_S3_ENDPOINT=https://minio.example.com
+
+# Key prefix within the S3 bucket (default: recordings/)
+# SORTIE_RECORDING_S3_PREFIX=recordings/
+
+# =============================================================================
 # JWT Authentication Configuration
 # =============================================================================
 

--- a/docs-site/.vitepress/config.ts
+++ b/docs-site/.vitepress/config.ts
@@ -22,6 +22,7 @@ export default defineConfig({
           { text: 'Templates', link: '/guide/templates' },
           { text: 'Sessions', link: '/guide/sessions' },
           { text: 'Session Sharing', link: '/guide/session-sharing' },
+          { text: 'Session Recording', link: '/guide/recording' },
         ],
       },
       {
@@ -32,6 +33,7 @@ export default defineConfig({
           { text: 'Kubernetes', link: '/admin/kubernetes' },
           { text: 'Reverse Proxy', link: '/admin/reverse-proxy' },
           { text: 'Data Persistence', link: '/admin/data-persistence' },
+          { text: 'Session Recording', link: '/admin/recording' },
           { text: 'Disaster Recovery', link: '/admin/disaster-recovery' },
           { text: 'Network Egress', link: '/admin/network-egress' },
         ],

--- a/docs-site/admin/data-persistence.md
+++ b/docs-site/admin/data-persistence.md
@@ -14,6 +14,7 @@ Sortie uses a layered persistence strategy:
 | Session Metadata | SQLite + in-memory cache | Server-side | Partial          |
 | Workspace Volume | Kubernetes emptyDir      | Pod-local   | No               |
 | Audit/Analytics  | SQLite database          | Server-side | Yes (with PVC)   |
+| Recordings       | Local filesystem or S3   | Server-side | Yes (with PVC or S3) |
 
 ## User Settings
 
@@ -498,6 +499,7 @@ Mounted via ConfigMap in Kubernetes deployments.
 | Audit logs       | SQLite `audit_log` table      | Database backup     |
 | Analytics        | SQLite `analytics` table      | Database backup     |
 | Branding config  | ConfigMap / JSON file         | GitOps              |
+| Recordings       | Local filesystem or S3        | PVC / S3 replication |
 | K8s manifests    | Git repository                | GitOps              |
 
 For production deployments:

--- a/docs-site/admin/index.md
+++ b/docs-site/admin/index.md
@@ -8,5 +8,6 @@ This section covers deploying, configuring, and operating Sortie in production e
 - [Kubernetes](./kubernetes.md) - Pod orchestration and container app setup
 - [Reverse Proxy](./reverse-proxy.md) - NGINX, Traefik, and Caddy configuration
 - [Data Persistence](./data-persistence.md) - Storage strategy and backup procedures
+- [Session Recording](./recording.md) - Video recording of container sessions
 - [Disaster Recovery](./disaster-recovery.md) - Backup, restore, and recovery procedures
 - [Network Egress](./network-egress.md) - Pod network traffic control policies

--- a/docs-site/admin/recording.md
+++ b/docs-site/admin/recording.md
@@ -1,0 +1,135 @@
+# Session Recording
+
+Session recording captures container sessions as `.webm` video files.
+Recordings are captured client-side in the browser and uploaded to a
+configurable storage backend (local filesystem or S3-compatible storage).
+
+## Enabling Recording
+
+Set the `SORTIE_VIDEO_RECORDING_ENABLED` environment variable to enable the
+recording feature:
+
+```bash
+SORTIE_VIDEO_RECORDING_ENABLED=true
+```
+
+When disabled (the default), recording API routes are not registered and the
+recording UI controls are hidden.
+
+## Storage Backends
+
+Sortie supports two storage backends for recording files.
+
+### Local Storage
+
+The default backend stores recordings on the local filesystem:
+
+```bash
+SORTIE_RECORDING_STORAGE_BACKEND=local
+SORTIE_RECORDING_STORAGE_PATH=/data/recordings
+```
+
+When using local storage with Kubernetes, mount a PersistentVolumeClaim at
+the storage path so recordings survive pod restarts.
+
+### S3 Storage
+
+For production deployments, use S3-compatible storage (AWS S3, MinIO, etc.):
+
+```bash
+SORTIE_RECORDING_STORAGE_BACKEND=s3
+SORTIE_RECORDING_S3_BUCKET=my-recordings-bucket
+SORTIE_RECORDING_S3_REGION=us-east-1
+SORTIE_RECORDING_S3_PREFIX=recordings/
+```
+
+For self-hosted S3-compatible storage like MinIO, set a custom endpoint:
+
+```bash
+SORTIE_RECORDING_S3_ENDPOINT=https://minio.example.com
+```
+
+AWS credentials are read from the standard AWS SDK credential chain
+(environment variables, shared credentials file, IAM role, etc.).
+
+### Environment Variable Reference
+
+| Variable | Type | Default | Description |
+|----------|------|---------|-------------|
+| `SORTIE_VIDEO_RECORDING_ENABLED` | bool | `false` | Enable session recording |
+| `SORTIE_RECORDING_STORAGE_BACKEND` | string | `local` | Storage backend: `local` or `s3` |
+| `SORTIE_RECORDING_STORAGE_PATH` | string | `/data/recordings` | Local storage directory |
+| `SORTIE_RECORDING_MAX_SIZE_MB` | int | `500` | Maximum upload size in MB |
+| `SORTIE_RECORDING_RETENTION_DAYS` | int | `0` | Days to retain recordings (0 = forever) |
+| `SORTIE_RECORDING_S3_BUCKET` | string | | S3 bucket name (required for S3 backend) |
+| `SORTIE_RECORDING_S3_REGION` | string | `us-east-1` | AWS region |
+| `SORTIE_RECORDING_S3_ENDPOINT` | string | | Custom S3 endpoint for MinIO |
+| `SORTIE_RECORDING_S3_PREFIX` | string | `recordings/` | Key prefix within the bucket |
+
+## Auto-Record
+
+Administrators can enable automatic recording for all sessions from the
+**Settings** tab in the admin panel. When auto-record is active, recording
+starts as soon as a container session enters the running state. Users can
+still stop recording manually.
+
+This setting is stored in the database and can be toggled at any time
+without restarting the server.
+
+## Retention Policy
+
+Configure automatic cleanup of old recordings with
+`SORTIE_RECORDING_RETENTION_DAYS`:
+
+```bash
+SORTIE_RECORDING_RETENTION_DAYS=30
+```
+
+When set to a value greater than zero, a cleanup job runs hourly and deletes
+recordings in the `ready` state that are older than the configured number of
+days. Recordings in other states (recording, uploading, failed) are not
+affected by retention cleanup.
+
+Set to `0` (the default) to keep recordings indefinitely.
+
+## Upload Limits
+
+The maximum recording upload size is controlled by
+`SORTIE_RECORDING_MAX_SIZE_MB` (default: 500 MB). Uploads exceeding this
+limit are rejected with a `413` status code. Adjust this based on expected
+session duration and video quality.
+
+## Helm Configuration
+
+The Helm chart exposes recording settings under the `recording` key in
+`values.yaml`:
+
+```yaml
+recording:
+  enabled: false
+  storageBackend: "local"    # "local" or "s3"
+  storagePath: "/data/recordings"
+  maxSizeMB: 500
+  retentionDays: 0           # 0 = keep forever
+  s3:
+    bucket: ""
+    region: "us-east-1"
+    endpoint: ""             # Custom S3 endpoint (MinIO)
+    prefix: "recordings/"
+```
+
+Set `recording.enabled: true` and configure the storage backend for your
+environment.
+
+## Managing Recordings
+
+Administrators can view and manage all recordings across all users from the
+**Recordings** tab in the admin panel. The admin view shows:
+
+- Recording ID and associated session
+- User who created the recording
+- Recording duration and file size
+- Current status
+
+Administrators can download or delete any recording regardless of ownership.
+Regular users can only manage their own recordings.

--- a/docs-site/developer/api-reference.md
+++ b/docs-site/developer/api-reference.md
@@ -111,6 +111,27 @@ See the [Session Sharing guide](/guide/session-sharing) for details.
 Shared sessions returned from `/api/sessions/shared` include extra
 fields: `is_shared`, `owner_username`, `share_permission`, and `share_id`.
 
+## Recordings
+
+These endpoints require `SORTIE_VIDEO_RECORDING_ENABLED=true`.
+
+| Method | Endpoint | Description |
+|--------|----------|-------------|
+| POST | `/api/sessions/:id/recording/start` | Start recording a session |
+| POST | `/api/sessions/:id/recording/stop` | Stop recording a session |
+| POST | `/api/sessions/:id/recording/upload` | Upload recorded video (multipart form) |
+| GET | `/api/recordings` | List current user's recordings |
+| GET | `/api/admin/recordings` | List all recordings (admin only) |
+| GET | `/api/recordings/:id/download` | Download a recording file |
+| DELETE | `/api/recordings/:id` | Delete a recording |
+
+The upload endpoint accepts a `multipart/form-data` request with fields
+`recording_id`, `duration` (optional), and `file` (the `.webm` video).
+
+Users can download and delete their own recordings. Administrators can
+access any user's recordings via the admin endpoint and can download or
+delete any recording.
+
 ## Templates
 
 | Method | Endpoint | Description |

--- a/docs-site/guide/index.md
+++ b/docs-site/guide/index.md
@@ -107,6 +107,7 @@ internal/
   config/            Configuration loading
   db/                SQLite database layer
   sessions/          Session lifecycle management
+  recordings/        Session video recording
   k8s/               Kubernetes pod orchestration
   websocket/         VNC WebSocket proxy
   guacamole/         Guacamole WebSocket proxy

--- a/docs-site/guide/recording.md
+++ b/docs-site/guide/recording.md
@@ -1,0 +1,47 @@
+# Session Recording
+
+Sortie can record your container sessions as video files. Recordings are
+captured client-side in the browser as `.webm` files and uploaded to the
+server when you stop recording.
+
+## Recording a Session
+
+Once your container session is running, you can start recording from the
+session viewer:
+
+1. Click the **Record** button in the session toolbar
+2. The button turns red to indicate recording is active
+3. Click the button again to stop recording
+4. The recording is automatically uploaded to the server
+
+If your administrator has enabled **auto-record**, recording starts
+automatically when the session launches. You can still stop it manually.
+
+## Managing Recordings
+
+Click **Recordings** in the header to view your recordings. From the
+recordings list you can:
+
+- See all your past recordings with session details and duration
+- Download a recording as a `.webm` file
+- Delete recordings you no longer need
+
+## Recording Status
+
+Each recording progresses through the following states:
+
+| Status | Meaning |
+|--------|---------|
+| `recording` | Capture is in progress |
+| `uploading` | Recording is being uploaded to the server |
+| `ready` | Upload complete, available for download |
+| `failed` | Upload or processing failed |
+
+Recordings in the `ready` state can be downloaded or deleted. Failed
+recordings can be deleted but not downloaded.
+
+## Storage and Retention
+
+Your administrator controls where recordings are stored and how long they
+are kept. Recordings may be automatically deleted after a retention period.
+See the [admin recording guide](/admin/recording) for configuration details.

--- a/docs-site/guide/sessions.md
+++ b/docs-site/guide/sessions.md
@@ -32,6 +32,7 @@ From the session manager you can:
 - See which sessions are currently running
 - Reconnect to a running session
 - [Share a session](/guide/session-sharing) with other users
+- [Record a session](/guide/recording) as a video
 - Terminate sessions you no longer need
 
 ## Session Timeout


### PR DESCRIPTION
## Summary

- Add user guide for session recording (`docs-site/guide/recording.md`) covering how to record, manage, and understand recording statuses
- Add admin guide for session recording (`docs-site/admin/recording.md`) covering enabling, storage backends (local/S3), env var reference, auto-record, retention, upload limits, and Helm config
- Add Recordings API section to `docs-site/developer/api-reference.md` with all 7 endpoints
- Add cross-references from sessions guide, admin index, getting started project layout, and data persistence tables
- Add video recording env vars to `.env.example`
- Add sidebar entries to VitePress config

## Test plan

- [x] `make docs` builds without errors
- [ ] Verify sidebar links render correctly in the docs site
- [ ] Verify all cross-links between pages resolve

🤖 Generated with [Claude Code](https://claude.com/claude-code)