### PR TITLE
Remove non-functional in-browser recording playback

### DIFF
--- a/web/src/components/RecordingsList.tsx
+++ b/web/src/components/RecordingsList.tsx
@@ -1,6 +1,5 @@
 import { useState, useEffect, useCallback } from 'react';
 import { listRecordings, downloadRecording, deleteRecording } from '../services/auth';
-import { RecordingPlayer } from './RecordingPlayer';
 import type { Recording, RecordingStatus } from '../types';
 
 interface RecordingsListProps {
@@ -53,7 +52,6 @@ export function RecordingsList({ isOpen, onClose, darkMode }: RecordingsListProp
   const [recordings, setRecordings] = useState<Recording[]>([]);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState('');
-  const [playingRecordingId, setPlayingRecordingId] = useState<string | null>(null);
 
   const loadRecordings = useCallback(async () => {
     setLoading(true);
@@ -203,15 +201,6 @@ export function RecordingsList({ isOpen, onClose, darkMode }: RecordingsListProp
                         </td>
                         <td className="py-3 text-right">
                           <div className="flex items-center justify-end gap-2">
-                            {recording.status === 'ready' && recording.format === 'vncrec' && (
-                              <button
-                                onClick={() => setPlayingRecordingId(recording.id)}
-                                className="text-blue-500 hover:text-blue-400 text-sm"
-                                title="Play"
-                              >
-                                Play
-                              </button>
-                            )}
                             {recording.status === 'ready' && (
                               <button
                                 onClick={() => handleDownload(recording)}
@@ -240,14 +229,6 @@ export function RecordingsList({ isOpen, onClose, darkMode }: RecordingsListProp
         </div>
       </div>
 
-      {/* Recording replay modal */}
-      {playingRecordingId && (
-        <RecordingPlayer
-          recordingId={playingRecordingId}
-          onClose={() => setPlayingRecordingId(null)}
-          darkMode={darkMode}
-        />
-      )}
     </div>
   );
 }


### PR DESCRIPTION
## Summary

- Remove the Play button from the recordings list modal
- Remove the RecordingPlayer component import and replay modal
- The in-browser VNC replay shows black video and is not functional

## Test plan

- [x] Frontend builds successfully
- [ ] Verify Play button no longer appears in recordings list

🤖 Generated with [Claude Code](https://claude.com/claude-code)