### PR TITLE
Sync Helm chart with all application config values

### DIFF
--- a/charts/sortie/templates/configmap.yaml
+++ b/charts/sortie/templates/configmap.yaml
@@ -9,13 +9,62 @@ metadata:
 data:
   # Database path must be in writable volume (readOnlyRootFilesystem is enabled)
   SORTIE_DB: "/data/sortie.db"
+  {{- if .Values.seed }}
+  SORTIE_SEED: {{ .Values.seed | quote }}
+  {{- end }}
+  # Branding configuration
+  {{- if .Values.branding.configPath }}
+  SORTIE_CONFIG: {{ .Values.branding.configPath | quote }}
+  {{- end }}
+  {{- if .Values.branding.logoURL }}
+  SORTIE_LOGO_URL: {{ .Values.branding.logoURL | quote }}
+  {{- end }}
+  SORTIE_PRIMARY_COLOR: {{ .Values.branding.primaryColor | quote }}
+  SORTIE_SECONDARY_COLOR: {{ .Values.branding.secondaryColor | quote }}
+  SORTIE_TENANT_NAME: {{ .Values.branding.tenantName | quote }}
+  # Session configuration
   SORTIE_SESSION_TIMEOUT: {{ .Values.session.timeout | quote }}
   SORTIE_SESSION_CLEANUP_INTERVAL: {{ .Values.session.cleanupInterval | quote }}
   SORTIE_POD_READY_TIMEOUT: {{ .Values.session.podReadyTimeout | quote }}
+  # Sidecar images
   SORTIE_VNC_SIDECAR_IMAGE: {{ .Values.vncSidecar.image | quote }}
   SORTIE_BROWSER_SIDECAR_IMAGE: {{ .Values.browserSidecar.image | quote }}
   SORTIE_GUACD_SIDECAR_IMAGE: {{ .Values.guacdSidecar.image | quote }}
+  # Gateway rate limiting
+  SORTIE_GATEWAY_RATE_LIMIT: {{ .Values.gateway.rateLimit | quote }}
+  SORTIE_GATEWAY_BURST: {{ .Values.gateway.burst | quote }}
+  # Session quotas
+  SORTIE_MAX_SESSIONS_PER_USER: {{ .Values.sessionQuotas.maxSessionsPerUser | quote }}
+  SORTIE_MAX_GLOBAL_SESSIONS: {{ .Values.sessionQuotas.maxGlobalSessions | quote }}
+  # Default session pod resources
+  SORTIE_DEFAULT_CPU_REQUEST: {{ .Values.sessionResources.cpuRequest | quote }}
+  SORTIE_DEFAULT_CPU_LIMIT: {{ .Values.sessionResources.cpuLimit | quote }}
+  SORTIE_DEFAULT_MEM_REQUEST: {{ .Values.sessionResources.memRequest | quote }}
+  SORTIE_DEFAULT_MEM_LIMIT: {{ .Values.sessionResources.memLimit | quote }}
+  # File transfer
+  SORTIE_MAX_UPLOAD_SIZE: {{ .Values.fileTransfer.maxUploadSize | int64 | quote }}
+  # Session queueing
+  SORTIE_QUEUE_MAX_SIZE: {{ .Values.queue.maxSize | quote }}
+  SORTIE_QUEUE_TIMEOUT: {{ .Values.queue.timeout | quote }}
+  {{- if .Values.oidc.enabled }}
+  # OIDC/SSO configuration
+  SORTIE_OIDC_ISSUER: {{ .Values.oidc.issuer | quote }}
+  SORTIE_OIDC_CLIENT_ID: {{ .Values.oidc.clientId | quote }}
+  SORTIE_OIDC_REDIRECT_URL: {{ .Values.oidc.redirectUrl | quote }}
+  {{- if .Values.oidc.scopes }}
+  SORTIE_OIDC_SCOPES: {{ .Values.oidc.scopes | quote }}
+  {{- end }}
+  {{- end }}
+  {{- if .Values.eventRecording.enabled }}
+  # Session event recording
+  SORTIE_RECORDING_ENABLED: "true"
+  {{- if .Values.eventRecording.endpoint }}
+  SORTIE_RECORDING_ENDPOINT: {{ .Values.eventRecording.endpoint | quote }}
+  {{- end }}
+  SORTIE_RECORDING_BUFFER_SIZE: {{ .Values.eventRecording.bufferSize | quote }}
+  {{- end }}
   {{- if .Values.recording.enabled }}
+  # Video recording
   SORTIE_VIDEO_RECORDING_ENABLED: "true"
   SORTIE_RECORDING_STORAGE_BACKEND: {{ .Values.recording.storageBackend | quote }}
   SORTIE_RECORDING_STORAGE_PATH: {{ .Values.recording.storagePath | quote }}
@@ -27,4 +76,10 @@ data:
   SORTIE_RECORDING_S3_ENDPOINT: {{ .Values.recording.s3.endpoint | quote }}
   SORTIE_RECORDING_S3_PREFIX: {{ .Values.recording.s3.prefix | quote }}
   {{- end }}
+  {{- end }}
+  {{- if .Values.billing.enabled }}
+  # Billing/metering
+  SORTIE_BILLING_ENABLED: "true"
+  SORTIE_BILLING_EXPORTER: {{ .Values.billing.exporter | quote }}
+  SORTIE_BILLING_EXPORT_INTERVAL: {{ .Values.billing.exportInterval | quote }}
   {{- end }}

--- a/charts/sortie/templates/deployment.yaml
+++ b/charts/sortie/templates/deployment.yaml
@@ -42,7 +42,7 @@ spec:
           envFrom:
             - configMapRef:
                 name: {{ include "sortie.fullname" . }}-config
-            {{- if .Values.auth.enabled }}
+            {{- if or .Values.auth.enabled (and .Values.oidc.enabled .Values.oidc.clientSecret) (and .Values.billing.enabled .Values.billing.webhookUrl) }}
             - secretRef:
                 name: {{ .Values.auth.existingSecret | default (printf "%s-auth" (include "sortie.fullname" .)) }}
             {{- end }}

--- a/charts/sortie/templates/secret.yaml
+++ b/charts/sortie/templates/secret.yaml
@@ -1,4 +1,4 @@
-{{- if and .Values.auth.enabled (not .Values.auth.existingSecret) }}
+{{- if or (and .Values.auth.enabled (not .Values.auth.existingSecret)) (and .Values.oidc.enabled .Values.oidc.clientSecret) (and .Values.billing.enabled .Values.billing.webhookUrl) }}
 ---
 apiVersion: v1
 kind: Secret
@@ -9,6 +9,7 @@ metadata:
     {{- include "sortie.labels" . | nindent 4 }}
 type: Opaque
 stringData:
+  {{- if and .Values.auth.enabled (not .Values.auth.existingSecret) }}
   {{- if .Values.auth.jwtSecret }}
   SORTIE_JWT_SECRET: {{ .Values.auth.jwtSecret | quote }}
   {{- else }}
@@ -22,4 +23,11 @@ stringData:
   SORTIE_ADMIN_PASSWORD: {{ .Values.auth.adminPassword | quote }}
   {{- end }}
   SORTIE_ALLOW_REGISTRATION: {{ .Values.auth.allowRegistration | quote }}
+  {{- end }}
+  {{- if and .Values.oidc.enabled .Values.oidc.clientSecret }}
+  SORTIE_OIDC_CLIENT_SECRET: {{ .Values.oidc.clientSecret | quote }}
+  {{- end }}
+  {{- if and .Values.billing.enabled .Values.billing.webhookUrl }}
+  SORTIE_BILLING_WEBHOOK_URL: {{ .Values.billing.webhookUrl | quote }}
+  {{- end }}
 {{- end }}

--- a/charts/sortie/values.yaml
+++ b/charts/sortie/values.yaml
@@ -3,6 +3,9 @@
 # Namespace configuration
 namespace: sortie
 
+# Seed data file path (optional, loads initial apps/categories on first run)
+seed: ""
+
 # Image configuration
 image:
   repository: ghcr.io/rjsadow/sortie
@@ -20,6 +23,14 @@ browserSidecar:
 # Guacd sidecar image for Windows RDP sessions
 guacdSidecar:
   image: guacamole/guacd:1.6.0
+
+# Branding configuration
+branding:
+  configPath: ""           # Path to branding config JSON
+  logoURL: ""              # Custom logo URL
+  primaryColor: "#1F2A3C"
+  secondaryColor: "#2B3445"
+  tenantName: "Sortie"
 
 # Replica count - supports >1 for horizontal scalability.
 # When replicaCount > 1, persistence.enabled must be true with a ReadWriteMany
@@ -46,11 +57,41 @@ auth:
   # Use existing secret instead of creating one
   existingSecret: ""
 
+# OIDC/SSO authentication configuration
+oidc:
+  enabled: false
+  issuer: ""
+  clientId: ""
+  clientSecret: ""
+  redirectUrl: ""
+  scopes: ""
+
 # Session configuration
 session:
   timeout: "120"           # Session timeout in minutes
   cleanupInterval: "5"     # Cleanup interval in minutes
   podReadyTimeout: "300"   # Pod ready timeout in seconds
+
+# Gateway rate limiting
+gateway:
+  rateLimit: 10            # Requests per second per IP (0 = disabled)
+  burst: 20                # Maximum burst size for rate limiter
+
+# Session quotas
+sessionQuotas:
+  maxSessionsPerUser: 5    # Maximum concurrent sessions per user (0 = unlimited)
+  maxGlobalSessions: 100   # Maximum concurrent sessions globally (0 = unlimited)
+
+# Default resource limits for session pods
+sessionResources:
+  cpuRequest: "500m"
+  cpuLimit: "2"
+  memRequest: "512Mi"
+  memLimit: "2Gi"
+
+# File transfer configuration
+fileTransfer:
+  maxUploadSize: 104857600  # Maximum upload file size in bytes (100MB)
 
 # Resource limits for the sortie server
 resources:
@@ -89,6 +130,12 @@ resourceQuota:
 limitRange:
   enabled: true
 
+# Session event recording configuration (lifecycle events, not video)
+eventRecording:
+  enabled: false
+  endpoint: ""             # Optional endpoint for recording events
+  bufferSize: 0            # Buffer size for async event processing
+
 # Video recording configuration
 recording:
   enabled: true
@@ -101,6 +148,18 @@ recording:
     region: "us-east-1"
     endpoint: ""             # Custom S3 endpoint (MinIO)
     prefix: "recordings/"
+
+# Billing/metering configuration
+billing:
+  enabled: false
+  exporter: "log"          # Exporter type: "log" or "webhook"
+  webhookUrl: ""           # Webhook URL (when exporter=webhook)
+  exportInterval: "5"      # Export interval in minutes
+
+# Session queueing configuration
+queue:
+  maxSize: 0               # Max queued requests when at capacity (0 = no queueing)
+  timeout: "30"            # Per-request queue wait timeout in seconds
 
 # Persistent storage for SQLite database.
 # Required for multi-replica deployments.

--- a/internal/config/chart_parity_test.go
+++ b/internal/config/chart_parity_test.go
@@ -1,0 +1,153 @@
+package config
+
+import (
+	"os"
+	"path/filepath"
+	"regexp"
+	"sort"
+	"strings"
+	"testing"
+)
+
+// TestHelmChartConfigParity ensures bidirectional parity between config.go's
+// SORTIE_* environment variables and the Helm chart templates. It catches:
+//  1. New env vars added to config.go but missing from the chart (forward drift)
+//  2. Env vars removed from config.go but still lingering in the chart (stale refs)
+//  3. Stale entries in either allowlist
+func TestHelmChartConfigParity(t *testing.T) {
+	// Env vars in config.go intentionally absent from the Helm chart.
+	// Every entry MUST have a justification.
+	notInChart := map[string]string{
+		"SORTIE_PORT": "Container port is hardcoded to 8080 in deployment.yaml",
+	}
+
+	// Env vars in the Helm chart that don't have a corresponding os.Getenv()
+	// in config.go. Every entry MUST have a justification.
+	notInConfig := map[string]string{
+		// (none currently — add entries here if needed)
+	}
+
+	configVars := extractEnvVarsFromSource(t, "config.go")
+	if len(configVars) == 0 {
+		t.Fatal("found no SORTIE_* env vars in config.go — extraction is broken")
+	}
+
+	chartVars := extractEnvVarsFromChartTemplates(t)
+	if len(chartVars) == 0 {
+		t.Fatal("found no SORTIE_* env vars in Helm chart templates — extraction is broken")
+	}
+
+	configSet := make(map[string]bool, len(configVars))
+	for _, v := range configVars {
+		configSet[v] = true
+	}
+
+	// Forward: config.go vars missing from chart
+	var missingFromChart []string
+	for _, v := range configVars {
+		if _, ok := notInChart[v]; ok {
+			continue
+		}
+		if !chartVars[v] {
+			missingFromChart = append(missingFromChart, v)
+		}
+	}
+	if len(missingFromChart) > 0 {
+		sort.Strings(missingFromChart)
+		t.Errorf("%d env var(s) in config.go missing from Helm chart:", len(missingFromChart))
+		for _, v := range missingFromChart {
+			t.Errorf("  - %s", v)
+		}
+		t.Error("Fix: add to charts/sortie/templates/ configmap.yaml or secret.yaml,")
+		t.Error("or add to notInChart allowlist with a justification.")
+	}
+
+	// Reverse: chart vars no longer in config.go
+	var staleInChart []string
+	for v := range chartVars {
+		if _, ok := notInConfig[v]; ok {
+			continue
+		}
+		if !configSet[v] {
+			staleInChart = append(staleInChart, v)
+		}
+	}
+	if len(staleInChart) > 0 {
+		sort.Strings(staleInChart)
+		t.Errorf("%d env var(s) in Helm chart no longer in config.go:", len(staleInChart))
+		for _, v := range staleInChart {
+			t.Errorf("  - %s", v)
+		}
+		t.Error("Fix: remove from charts/sortie/templates/ and values.yaml,")
+		t.Error("or add to notInConfig allowlist with a justification.")
+	}
+
+	// Verify allowlists don't accumulate stale entries
+	for v := range notInChart {
+		if !configSet[v] {
+			t.Errorf("notInChart entry %q no longer exists in config.go — remove it", v)
+		}
+	}
+	for v := range notInConfig {
+		if !chartVars[v] {
+			t.Errorf("notInConfig entry %q no longer exists in Helm chart — remove it", v)
+		}
+	}
+}
+
+// extractEnvVarsFromSource reads a Go source file in the current package
+// directory and returns all unique SORTIE_* names found in os.Getenv() calls.
+func extractEnvVarsFromSource(t *testing.T, filename string) []string {
+	t.Helper()
+
+	data, err := os.ReadFile(filename)
+	if err != nil {
+		t.Fatalf("failed to read %s: %v", filename, err)
+	}
+
+	re := regexp.MustCompile(`os\.Getenv\("(SORTIE_[A-Z0-9_]+)"\)`)
+	matches := re.FindAllStringSubmatch(string(data), -1)
+
+	seen := make(map[string]bool)
+	var vars []string
+	for _, m := range matches {
+		name := m[1]
+		if !seen[name] {
+			seen[name] = true
+			vars = append(vars, name)
+		}
+	}
+
+	sort.Strings(vars)
+	return vars
+}
+
+// extractEnvVarsFromChartTemplates reads all YAML files under
+// charts/sortie/templates/ and returns a set of all SORTIE_* names found.
+func extractEnvVarsFromChartTemplates(t *testing.T) map[string]bool {
+	t.Helper()
+
+	chartDir := filepath.Join("..", "..", "charts", "sortie", "templates")
+	entries, err := os.ReadDir(chartDir)
+	if err != nil {
+		t.Fatalf("failed to read chart templates dir %s: %v", chartDir, err)
+	}
+
+	re := regexp.MustCompile(`SORTIE_[A-Z0-9_]+`)
+	vars := make(map[string]bool)
+
+	for _, entry := range entries {
+		if entry.IsDir() || !strings.HasSuffix(entry.Name(), ".yaml") {
+			continue
+		}
+		data, err := os.ReadFile(filepath.Join(chartDir, entry.Name()))
+		if err != nil {
+			t.Fatalf("failed to read %s: %v", entry.Name(), err)
+		}
+		for _, m := range re.FindAllString(string(data), -1) {
+			vars[m] = true
+		}
+	}
+
+	return vars
+}


### PR DESCRIPTION
## Summary
- Add 25 missing `SORTIE_*` env vars to the Helm chart (branding, OIDC/SSO, rate limiting, session quotas, resource defaults, file transfer, event recording, billing, queueing)
- Add values.yaml sections: `seed`, `branding`, `oidc`, `gateway`, `sessionQuotas`, `sessionResources`, `fileTransfer`, `eventRecording`, `billing`, `queue`
- Widen secret.yaml and deployment.yaml guards to handle OIDC client secret and billing webhook URL
- Add bidirectional parity test (`TestHelmChartConfigParity`) that fails CI if config.go and chart templates drift in either direction

## Test plan
- [x] `helm template charts/sortie/` — default values render correctly, no conditional sections leak
- [x] `helm template --set oidc.enabled=true,...` — OIDC vars appear in ConfigMap + Secret
- [x] `helm template --set billing.enabled=true,...` — billing vars in ConfigMap + webhook in Secret
- [x] `helm template --set eventRecording.enabled=true` — event recording vars in ConfigMap
- [x] `helm lint charts/sortie/` — passes with defaults and all features enabled
- [x] `go test -run TestHelmChartConfigParity ./internal/config/` — passes
- [x] `go test ./internal/config/` — full config test suite passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)