### PR TITLE
Add explicit S3 access key authentication for recording storage

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -133,6 +133,11 @@ SORTIE_DEFAULT_MEM_LIMIT=2Gi
 # Key prefix within the S3 bucket (default: recordings/)
 # SORTIE_RECORDING_S3_PREFIX=recordings/
 
+# Explicit S3 access key credentials (optional)
+# When both are set, these are used instead of the default AWS credential chain.
+# SORTIE_RECORDING_S3_ACCESS_KEY_ID=AKIA...
+# SORTIE_RECORDING_S3_SECRET_ACCESS_KEY=...
+
 # =============================================================================
 # JWT Authentication Configuration
 # =============================================================================

--- a/charts/sortie/templates/deployment.yaml
+++ b/charts/sortie/templates/deployment.yaml
@@ -51,6 +51,20 @@ spec:
               valueFrom:
                 fieldRef:
                   fieldPath: metadata.namespace
+            {{- if and .Values.recording.s3.existingSecret.accessKeyID.name .Values.recording.s3.existingSecret.accessKeyID.key }}
+            - name: SORTIE_RECORDING_S3_ACCESS_KEY_ID
+              valueFrom:
+                secretKeyRef:
+                  name: {{ .Values.recording.s3.existingSecret.accessKeyID.name | quote }}
+                  key: {{ .Values.recording.s3.existingSecret.accessKeyID.key | quote }}
+            {{- end }}
+            {{- if and .Values.recording.s3.existingSecret.secretAccessKey.name .Values.recording.s3.existingSecret.secretAccessKey.key }}
+            - name: SORTIE_RECORDING_S3_SECRET_ACCESS_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: {{ .Values.recording.s3.existingSecret.secretAccessKey.name | quote }}
+                  key: {{ .Values.recording.s3.existingSecret.secretAccessKey.key | quote }}
+            {{- end }}
           resources:
             {{- toYaml .Values.resources | nindent 12 }}
           securityContext:

--- a/charts/sortie/templates/secret.yaml
+++ b/charts/sortie/templates/secret.yaml
@@ -1,4 +1,4 @@
-{{- if or (and .Values.auth.enabled (not .Values.auth.existingSecret)) (and .Values.oidc.enabled .Values.oidc.clientSecret) (and .Values.billing.enabled .Values.billing.webhookUrl) }}
+{{- if or (and .Values.auth.enabled (not .Values.auth.existingSecret)) (and .Values.oidc.enabled .Values.oidc.clientSecret) (and .Values.billing.enabled .Values.billing.webhookUrl) (and .Values.recording.s3.accessKeyID (not .Values.recording.s3.existingSecret.accessKeyID.name)) (and .Values.recording.s3.secretAccessKey (not .Values.recording.s3.existingSecret.secretAccessKey.name)) }}
 ---
 apiVersion: v1
 kind: Secret
@@ -29,5 +29,11 @@ stringData:
   {{- end }}
   {{- if and .Values.billing.enabled .Values.billing.webhookUrl }}
   SORTIE_BILLING_WEBHOOK_URL: {{ .Values.billing.webhookUrl | quote }}
+  {{- end }}
+  {{- if and .Values.recording.s3.accessKeyID (not .Values.recording.s3.existingSecret.accessKeyID.name) }}
+  SORTIE_RECORDING_S3_ACCESS_KEY_ID: {{ .Values.recording.s3.accessKeyID | quote }}
+  {{- end }}
+  {{- if and .Values.recording.s3.secretAccessKey (not .Values.recording.s3.existingSecret.secretAccessKey.name) }}
+  SORTIE_RECORDING_S3_SECRET_ACCESS_KEY: {{ .Values.recording.s3.secretAccessKey | quote }}
   {{- end }}
 {{- end }}

--- a/charts/sortie/values.yaml
+++ b/charts/sortie/values.yaml
@@ -148,6 +148,15 @@ recording:
     region: "us-east-1"
     endpoint: ""             # Custom S3 endpoint (MinIO)
     prefix: "recordings/"
+    accessKeyID: ""          # Explicit AWS access key ID (optional)
+    secretAccessKey: ""      # Explicit AWS secret access key (optional)
+    existingSecret:
+      accessKeyID:
+        name: ""             # K8s Secret name containing the access key ID
+        key: ""              # Key within that Secret
+      secretAccessKey:
+        name: ""             # K8s Secret name containing the secret access key
+        key: ""              # Key within that Secret
 
 # Billing/metering configuration
 billing:

--- a/go.mod
+++ b/go.mod
@@ -5,6 +5,7 @@ go 1.25.0
 require (
 	github.com/aws/aws-sdk-go-v2 v1.41.1
 	github.com/aws/aws-sdk-go-v2/config v1.32.7
+	github.com/aws/aws-sdk-go-v2/credentials v1.19.7
 	github.com/aws/aws-sdk-go-v2/service/s3 v1.96.0
 	github.com/coreos/go-oidc/v3 v3.17.0
 	github.com/golang-jwt/jwt/v5 v5.3.1
@@ -24,7 +25,6 @@ require (
 require (
 	github.com/Masterminds/semver/v3 v3.4.0 // indirect
 	github.com/aws/aws-sdk-go-v2/aws/protocol/eventstream v1.7.4 // indirect
-	github.com/aws/aws-sdk-go-v2/credentials v1.19.7 // indirect
 	github.com/aws/aws-sdk-go-v2/feature/ec2/imds v1.18.17 // indirect
 	github.com/aws/aws-sdk-go-v2/internal/configsources v1.4.17 // indirect
 	github.com/aws/aws-sdk-go-v2/internal/endpoints/v2 v2.7.17 // indirect

--- a/internal/recordings/storage_s3.go
+++ b/internal/recordings/storage_s3.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/aws/aws-sdk-go-v2/aws"
 	awsconfig "github.com/aws/aws-sdk-go-v2/config"
+	"github.com/aws/aws-sdk-go-v2/credentials"
 	"github.com/aws/aws-sdk-go-v2/service/s3"
 )
 
@@ -27,10 +28,17 @@ type S3Store struct {
 
 // NewS3Store creates an S3Store configured from AWS defaults and the given parameters.
 // An empty endpoint uses the standard AWS S3 endpoint; a non-empty endpoint targets
-// MinIO or another S3-compatible service.
-func NewS3Store(bucket, region, endpoint, prefix string) (*S3Store, error) {
+// MinIO or another S3-compatible service. When accessKeyID and secretAccessKey are
+// both non-empty, static credentials are used instead of the default credential chain.
+func NewS3Store(bucket, region, endpoint, prefix, accessKeyID, secretAccessKey string) (*S3Store, error) {
 	opts := []func(*awsconfig.LoadOptions) error{
 		awsconfig.WithRegion(region),
+	}
+
+	if accessKeyID != "" && secretAccessKey != "" {
+		opts = append(opts, awsconfig.WithCredentialsProvider(
+			credentials.NewStaticCredentialsProvider(accessKeyID, secretAccessKey, ""),
+		))
 	}
 
 	cfg, err := awsconfig.LoadDefaultConfig(context.Background(), opts...)

--- a/main.go
+++ b/main.go
@@ -262,6 +262,8 @@ func main() {
 				appConfig.RecordingS3Region,
 				appConfig.RecordingS3Endpoint,
 				appConfig.RecordingS3Prefix,
+				appConfig.RecordingS3AccessKeyID,
+				appConfig.RecordingS3SecretAccessKey,
 			)
 			if err != nil {
 				slog.Error("failed to initialize S3 recording store", "error", err)


### PR DESCRIPTION
## Summary
- Add `SORTIE_RECORDING_S3_ACCESS_KEY_ID` and `SORTIE_RECORDING_S3_SECRET_ACCESS_KEY` env vars for configuring explicit AWS credentials on the S3 recording storage backend
- When both are set, `NewS3Store()` uses `credentials.NewStaticCredentialsProvider()` instead of the default AWS credential chain
- Config validation ensures both must be set together (setting only one is an error)
- Helm chart supports inline values (`recording.s3.accessKeyID`/`secretAccessKey`) stored in the chart-managed Secret, or references to existing K8s Secrets via `recording.s3.existingSecret`

Closes #21

## Test plan
- [x] `make test` — all unit tests pass (including `TestHelmChartConfigParity`)
- [x] `go test -v -run TestS3 ./internal/recordings/` — existing S3 store tests pass (they use `NewS3StoreWithClient`, unaffected)
- [x] `golangci-lint run ./...` — 0 issues
- [ ] Manual: deploy with explicit S3 credentials and verify recording upload to a private bucket

🤖 Generated with [Claude Code](https://claude.com/claude-code)