### PR TITLE
ci: restrict workflow token permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,9 @@ on:
   pull_request:
     branches: [main]
 
+permissions:
+  contents: read
+
 env:
   GO_VERSION: "1.25"
   NODE_VERSION: "22"


### PR DESCRIPTION
## Summary
Adds an explicit top-level `permissions` block to the CI workflow with `contents: read`. This gives the workflow the minimum repository token scope needed for checkout/read-only jobs instead of relying on GitHub's default token permissions.

This addresses #63 without changing the trigger, job matrix, actions, or build/test behavior.

## Verification
- Parsed `.github/workflows/ci.yml` with PyYAML and confirmed `permissions.contents == "read"`
- Ran `git diff --check`

Closes #63
